### PR TITLE
Add that F11 activates full-screen in Linux

### DIFF
--- a/40.Qol.md
+++ b/40.Qol.md
@@ -16,7 +16,7 @@ My selection is purely subjective, and aimed at long-form writing as opposed to 
 
 ## Show Emacs full-screen
 
-This is not configuration. Just to be sure that this is an option you have natively on Windows. Press <kbd>F11</kbd> to toggle the full-screen mode on and off. No need for special configuration in Emacs. 
+This is not configuration. Just to be sure that this is an option you have natively on Windows. Press <kbd>F11</kbd> to toggle the full-screen mode on and off. No need for special configuration in Emacs. (This also works in KDE on Linux and may work in other window managers also. Just try it!)
 
 ## Set your font
 


### PR DESCRIPTION
Add mention that F11 activates full-screen on Linux
KDE and may work for other window managers as well.

Signed-off-by: Stephen Bosch <posting@vodacomm.ca>