### PR TITLE
Fix faulty reference to 'M-h e'

### DIFF
--- a/30.Set-up-Org-roam.md
+++ b/30.Set-up-Org-roam.md
@@ -114,7 +114,7 @@ The first line with `add-to-list` tells Emacs where it can find `sqlite3.exe`.  
 
 ![Add Org-roam configuration](images/44162dc292c18ef3c8e5475fbf2fd09a.png)
 
-Now you can save this. Let's quit Emacs and relaunch it. Once you see the start screen, invoke `M-h e` to view "echo message." Do you notice the two files and one link you created earlier have been added to Org-roam's database?
+Now you can save this. Let's quit Emacs and relaunch it. Once you see the start screen, invoke `C-h e` to view "echo message." Do you notice the two files and one link you created earlier have been added to Org-roam's database?
 
 ![Launch Org-roam and confirm your Org-roam db has been updated](images/1780d79dea3f210c3d50e610241b5f82.png)
 


### PR DESCRIPTION
Fix faulty reference to 'M-h e', should be 'C-h e'.

Signed-off-by: Stephen Bosch <posting@vodacomm.ca>